### PR TITLE
Fix configuration issue from refactor cleanup. 

### DIFF
--- a/git_spec.gemspec
+++ b/git_spec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end

--- a/lib/git_spec.rb
+++ b/lib/git_spec.rb
@@ -12,7 +12,7 @@ module GitSpec
   end
 
   def self.configure
-    self.configuration ||= Configuration.new
+    @configuration ||= Configuration.new
 
     yield(configuration)
 

--- a/lib/git_spec/cli.rb
+++ b/lib/git_spec/cli.rb
@@ -7,10 +7,8 @@ module GitSpec
     method_option :src_root, default: 'lib/'
     method_option :log_level, type: :numeric, default: Logger::INFO, aliases: ['-l']
     method_option :dry_run, type: :boolean, default: false, aliases: ['-d']
-    method_option :project_root, default: Dir.getwd
     def spec
       GitSpec.configure do |config|
-        config.git_root = options.project_root
         config.src_root = options.src_root
         config.log_level = options.log_level
       end

--- a/lib/git_spec/version.rb
+++ b/lib/git_spec/version.rb
@@ -1,3 +1,3 @@
 module GitSpec
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
When switching from ruby-git to system git commands, no longer need the project_root/git_root configuration option. Updates config options and setting from the previous refactor.

Also includes rubygems publish URL update.