### PR TITLE
Configuration can now be loaded from gem_spec.yml. Fixes #3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in git_spec.gemspec
 gemspec
+
+group :development do
+  gem "pry"
+  gem "rspec", "~> 3.5"
+end

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Options:
 --log_level="Logger::INFO" - The log level.   
 
 --dry_run="true", Aliases: -d - Should the test runner be executed? When in dry run mode, the list of files that would be sent to the test runner will be output.   
+
+### Shared Configuration
+
+GitSpec will look in the current directory for a `git_spec.yml` configuration file. See lib/git_spec/configuration.rb for overridable options.
     
+Options provided on the command line will take precedence over values supplied in the configuration file.    
 
 ## Development
 

--- a/git_spec.gemspec
+++ b/git_spec.gemspec
@@ -31,7 +31,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'thor', '~> 0', '>= 0.19.0'
 
+  ##
+  # Uncomment to have debugger tools bundled with gem
+  # spec.add_runtime_dependency 'pry'
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/git_spec/cli.rb
+++ b/lib/git_spec/cli.rb
@@ -3,14 +3,15 @@ require 'thor'
 module GitSpec
   class CLI < Thor
     desc "spec [COMMAND]", "Execute COMMAND with files arg"
-    method_option :command, default: 'bundle exec rspec', aliases: ['-c']
-    method_option :src_root, default: 'lib/'
-    method_option :log_level, type: :numeric, default: Logger::INFO, aliases: ['-l']
+    method_option :command, aliases: ['-c']
+    method_option :src_root
+    method_option :log_level, type: :numeric, aliases: ['-l']
     method_option :dry_run, type: :boolean, default: false, aliases: ['-d']
     def spec
       GitSpec.configure do |config|
-        config.src_root = options.src_root
-        config.log_level = options.log_level
+        config.spec_command = options.command if options.command
+        config.src_root = options.src_root if options.src_root
+        config.log_level = options.log_level if options.log_level
       end
 
       files, missing_files = GitSpec.changed_files
@@ -21,7 +22,7 @@ module GitSpec
         say("Dry run enabled. Would have sent the following files to the spec runner:", :yellow)
         say(files.join(' '), :yellow)
       else
-        system "#{options.command} #{files.join(' ')}"
+        system "#{GitSpec.configuration.spec_command} #{files.join(' ')}"
       end
 
     end

--- a/lib/git_spec/configuration.rb
+++ b/lib/git_spec/configuration.rb
@@ -1,11 +1,57 @@
+require 'yaml'
+
 module GitSpec
   class Configuration
-    attr_accessor :src_root, :log_level
+    attr_accessor :src_root, :log_level, :spec_command
 
+    ##
+    # List of configuration options safe for the outside world to set freely
+    #
+    OVERRIDABLE_OPTIONS = [:src_root, :log_level, :spec_command]
 
     def initialize
       @src_root = 'lib/'
       @log_level = ::Logger::INFO
+      @spec_command = 'bundle exec rspec'
+
+      merge_file_overrides
+    end
+
+    private
+
+    ##
+    # Load the file based config file and merge the safe options into the configuration.
+    #
+    def merge_file_overrides
+      options = safe_options(load_file)
+      options.each do |k, v|
+        self.public_send("#{k}=".to_sym, v)
+      end
+    end
+
+    ##
+    # Load the git_spec.yml configuration file
+    #
+    # @return [Hash]
+    # @return [NilClass] if the file doesn't exist or there was a parser error
+    #
+    def load_file
+      config_path = ::File.join(Dir.getwd, 'git_spec.yml')
+      YAML.load_file(config_path) if ::File.exists?(config_path)
+    rescue => e
+      puts "Error parsing GitSpec configuration file at #{config_path}. Please check for syntax errors and try again."
+    end
+
+    ##
+    # Select the options users are allowed to override from the raw, unsafe config
+    #
+    # @param [Hash] unsafe_config Hash containing safe/unsafe key/value pairs
+    #
+    # @return [Hash]
+    #
+    def safe_options(unsafe_config)
+      return {} unless unsafe_config.respond_to?(:select)
+      unsafe_config.select{|c| OVERRIDABLE_OPTIONS.include?(c.to_sym)}
     end
   end
 end

--- a/lib/git_spec/version.rb
+++ b/lib/git_spec/version.rb
@@ -1,3 +1,3 @@
 module GitSpec
-  VERSION = "0.1.1"
+  VERSION = "0.2.0-alpha"
 end

--- a/spec/fixtures/files/git_spec.yml
+++ b/spec/fixtures/files/git_spec.yml
@@ -1,0 +1,1 @@
+src_root: "app/"

--- a/spec/fixtures/files/unsafe_git_spec.yml
+++ b/spec/fixtures/files/unsafe_git_spec.yml
@@ -1,0 +1,2 @@
+bad_key: "This attribute should not be set on the config object"
+src_root: "app/"

--- a/spec/git_spec/configuration_spec.rb
+++ b/spec/git_spec/configuration_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../spec_helper'
+require 'yaml'
+
+RSpec.describe GitSpec::Configuration do
+  subject(:config) { described_class }
+
+  let(:git_spec_path) { ::File.join(Dir.getwd, 'git_spec.yml') }
+  let(:git_spec_fixture_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'git_spec.yml') }
+  let(:git_spec_unsafe_fixture_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'unsafe_git_spec.yml') }
+
+  before do
+    allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
+  end
+
+  describe "#initialize" do
+    it "uses default values" do
+      config = subject.new
+
+      expect(config.src_root).to eq "lib/"
+      expect(config.log_level).to eq ::Logger::INFO
+    end
+
+    context "when a git_spec.yml is provided" do
+      let!(:config_fixture) { YAML.load_file(git_spec_fixture_path) }
+
+      before do
+        allow(YAML).to receive(:load_file).with(git_spec_path).and_return(config_fixture)
+        allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
+      end
+
+      it "overrides the default config" do
+        config = subject.new
+        expect(config.src_root).to eq "app/"
+      end
+
+      context "and the git_spec.yml declares unknown/unsafe attributes" do
+        let!(:config_fixture) { YAML.load_file(git_spec_unsafe_fixture_path) }
+
+        it "doesn't try to set the unknown attribute" do
+          expect {
+            subject.new
+          }.not_to raise_error
+        end
+
+        it "overrides the default config with the valid options" do
+          config = subject.new
+          expect(config.src_root).to eq "app/"
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
+require 'pry'
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "git_spec"


### PR DESCRIPTION
GitSpec can will look in the current directory for a `git_spec.yml` configuration file. See lib/git_spec/configuration.rb for overridable options.
    
Options provided on the command line will take precedence over values supplied in the configuration file.  