### PR TITLE
Add customizable exclusion file patterns. Fix #2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gemspec
 
 group :development do
   gem "pry"
+  gem "pry-byebug"
   gem "rspec", "~> 3.5"
 end

--- a/exe/gspec
+++ b/exe/gspec
@@ -1,12 +1,20 @@
 #!/usr/bin/env ruby
 
-# Exit cleanly from an early interrupt
-Signal.trap("INT") { exit 1 }
-
-# require "lib/git_spec"
-#
-# system "bundle exec #{ARGV.first} #{GitSpec.files}"
-#
 require 'git_spec'
 require 'git_spec/cli'
+
+# Interrupting our process doesn't interrupt any subcommands we may be executing, so we have to keep a
+# running list of commands we have executed so we can pass the INT signal to them as well.
+#
+# @see lib/git_spec/cli.rb
+#
+Signal.trap("INT") do
+
+  GitSpec::CLI::RUNNING_PIDS.each do |pid|
+    Process.kill("INT", pid)
+  end
+
+  exit 1
+end
+
 GitSpec::CLI.start

--- a/lib/git_spec/file.rb
+++ b/lib/git_spec/file.rb
@@ -1,8 +1,5 @@
 module GitSpec
   class File
-    # TODO: Move this to the config
-    EXCLUDED_FILE_PATTERNS = [/^exe\//, /^spec\//, /^vendor\//, /^config\//, /^regression_tests\//, /^\./]
-
     attr_reader :configuration, :path
 
     def initialize(filename, configuration = GitSpec.configuration)
@@ -45,7 +42,8 @@ module GitSpec
 
     def should_filter?(filename)
       should_exclude = false
-      EXCLUDED_FILE_PATTERNS.each do |pattern|
+
+      configuration.excluded_file_patterns.each do |pattern|
         match = filename =~ pattern
 
         unless match.nil?

--- a/spec/fixtures/files/custom_git_spec.yml
+++ b/spec/fixtures/files/custom_git_spec.yml
@@ -1,5 +1,4 @@
 <% require 'logger' %>
-i_want_secrets: true, # An unexpected config option
 excluded_file_patterns:
   - !ruby/regexp /^exe\//
   - !ruby/regexp /^spec\//
@@ -8,5 +7,5 @@ excluded_file_patterns:
   - !ruby/regexp /^regression_tests\//
   - !ruby/regexp /^\./
 log_level: <%= ::Logger::DEBUG %>
-src_root: 'app/'
 spec_command: 'bundle exec rspec'
+src_root: 'app/'

--- a/spec/fixtures/files/git_spec.yml
+++ b/spec/fixtures/files/git_spec.yml
@@ -1,1 +1,0 @@
-src_root: "app/"

--- a/spec/git_spec/configuration_spec.rb
+++ b/spec/git_spec/configuration_spec.rb
@@ -4,37 +4,50 @@ require 'yaml'
 RSpec.describe GitSpec::Configuration do
   subject(:config) { described_class }
 
+  let!(:project_root) { Dir.getwd }
   let(:git_spec_path) { ::File.join(Dir.getwd, 'git_spec.yml') }
-  let(:git_spec_fixture_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'git_spec.yml') }
-  let(:git_spec_unsafe_fixture_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'unsafe_git_spec.yml') }
+  let(:custom_git_spec_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'custom_git_spec.yml') }
+  let(:unsafe_git_spec_path) { File.join(Dir.getwd, 'spec', 'fixtures', 'files', 'unsafe_git_spec.yml') }
+
+  let(:default_regexps) { [/^exe\//, /^spec\//, /^vendor\//, /^config\//, /^regression_tests\//, /^\./] }
 
   before do
-    allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
+    # allow(::File).to receive(:join).with(Dir.getwd, 'git_spec.yml').and_call_original
+    # allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
   end
 
   describe "#initialize" do
     it "uses default values" do
       config = subject.new
 
-      expect(config.src_root).to eq "lib/"
+      matched_regexps = config.excluded_file_patterns.each_with_object([]) do |pattern, matched|
+        expect(pattern).to be_kind_of(Regexp)
+        matched << pattern
+      end
+      expect(matched_regexps.map(&:to_s)).to match_array(default_regexps.map(&:to_s))
+
       expect(config.log_level).to eq ::Logger::INFO
+      expect(config.spec_command).to eq 'bundle exec rspec'
+      expect(config.src_root).to eq 'lib/'
     end
 
-    context "when a git_spec.yml is provided" do
-      let!(:config_fixture) { YAML.load_file(git_spec_fixture_path) }
-
+    context "when a custom git_spec.yml is provided" do
       before do
-        allow(YAML).to receive(:load_file).with(git_spec_path).and_return(config_fixture)
-        allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
+        allow(::File).to receive(:join).with(project_root, 'git_spec.yml').and_return(custom_git_spec_path)
       end
 
       it "overrides the default config" do
         config = subject.new
+
+        expect(config.log_level).to eq ::Logger::DEBUG
         expect(config.src_root).to eq "app/"
       end
 
       context "and the git_spec.yml declares unknown/unsafe attributes" do
-        let!(:config_fixture) { YAML.load_file(git_spec_unsafe_fixture_path) }
+        before do
+          allow(::File).to receive(:join).and_call_original
+          allow(::File).to receive(:join).with(project_root, 'git_spec.yml').and_return(unsafe_git_spec_path)
+        end
 
         it "doesn't try to set the unknown attribute" do
           expect {

--- a/spec/git_spec_spec.rb
+++ b/spec/git_spec_spec.rb
@@ -5,7 +5,7 @@ describe GitSpec do
     expect(GitSpec::VERSION).not_to be nil
   end
 
-  it "does something useful" do
+  xit "does something useful" do
     expect(false).to eq(true)
   end
 end


### PR DESCRIPTION
Additional enhancements to the configuration object to
use a YAML file based configuration. This will make it
easier for others to customize git_spec to their environment.

Also made some improvements to how gspec handles the INT signal.