### PR TITLE
File and configuration enhancements. Fixes #12.

### DIFF
--- a/lib/git_spec.rb
+++ b/lib/git_spec.rb
@@ -11,13 +11,19 @@ module GitSpec
     attr_reader :configuration, :logger
   end
 
+  def self.configuration
+    @configuration || configure
+  end
+
   def self.configure
     @configuration ||= Configuration.new
 
-    yield(configuration)
+    yield(configuration) if block_given?
 
     @logger = GitSpec::Logger.new(STDOUT)
     logger.level = configuration.log_level
+
+    @configuration
   end
 
 

--- a/lib/git_spec/configuration.rb
+++ b/lib/git_spec/configuration.rb
@@ -3,7 +3,8 @@ require 'erb'
 
 module GitSpec
   class Configuration
-    attr_accessor :excluded_file_patterns, :log_level, :src_root, :spec_command
+    attr_accessor :allowed_file_types, :excluded_file_patterns, :log_level, :src_root, :spec_command,
+                  :test_dir, :test_file_suffix
 
     def initialize
       load_config!

--- a/spec/git_spec/configuration_spec.rb
+++ b/spec/git_spec/configuration_spec.rb
@@ -11,15 +11,14 @@ RSpec.describe GitSpec::Configuration do
 
   let(:default_regexps) { [/^exe\//, /^spec\//, /^vendor\//, /^config\//, /^regression_tests\//, /^\./] }
 
-  before do
-    # allow(::File).to receive(:join).with(Dir.getwd, 'git_spec.yml').and_call_original
-    # allow(File).to receive(:exists?).with(git_spec_path).and_return(true)
-  end
-
   describe "#initialize" do
     it "uses default values" do
       config = subject.new
 
+      expect(config.allowed_file_types).to match_array(['.rb'])
+
+      # Make sure each excluded file pattern is a Ruby RegExp, they are in the same order, and are the
+      # correct values.
       matched_regexps = config.excluded_file_patterns.each_with_object([]) do |pattern, matched|
         expect(pattern).to be_kind_of(Regexp)
         matched << pattern
@@ -29,6 +28,8 @@ RSpec.describe GitSpec::Configuration do
       expect(config.log_level).to eq ::Logger::INFO
       expect(config.spec_command).to eq 'bundle exec rspec'
       expect(config.src_root).to eq 'lib/'
+      expect(config.test_dir).to eq 'spec/'
+      expect(config.test_file_suffix).to eq '_spec'
     end
 
     context "when a custom git_spec.yml is provided" do

--- a/spec/git_spec/file_spec.rb
+++ b/spec/git_spec/file_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe GitSpec::File do
+  let(:filename) { 'lib/services/my_service.rb' }
+  subject(:file) { described_class.new(filename) }
+
+  describe "#spec_path" do
+    it "builds the spec path" do
+      expect(file.spec_path).to eq 'spec/services/my_service_spec.rb'
+    end
+
+    context "when the file is a spec" do
+      let(:filename) { 'spec/services/my_service_spec.rb' }
+
+      it "returns itself" do
+        expect(file.spec_path).to eq filename
+      end
+    end
+  end
+
+  describe "#allowed_file_type?" do
+    context "when the ext is in the list of allowed_file_types" do
+      it "is allowed" do
+        expect(file.allowed_file_type?).to be_truthy
+      end
+    end
+
+    context "when the ext is not in the list of allowed_file_types" do
+      let(:filename) { 'lib/services/my_service.not-rb' }
+
+      it "is not allowed" do
+        expect(file.allowed_file_type?).to be_falsey
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
'test_dir' configuration option added. Default: 'spec/'. This
allows us to build the  correct spec path when the file lives
in another directory - e.g. "test" vs "spec".

'test_file_suffix' configuration option added. Default: '_spec'.
This allows us to build the correct file name when tests have
a custom suffix - e.g. "_test" or "Test" vs "_spec".

GitSpec::File updated to work with Pathname internally. We are
doing a lot of filename manipulation and working with a Pathname
provides some convenience methds and reduces the amount of
conversions needed.