### PR TITLE
Add Travis build status to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.2.3
 before_install: gem install bundler -v 1.13.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitSpec
 
+[![Build Status](https://travis-ci.org/billthompson/git_spec.svg?branch=master)](https://travis-ci.org/billthompson/git_spec)
+
 Execute your test runner for files in your git diff.
 
 Examples:

--- a/git_spec.yml
+++ b/git_spec.yml
@@ -1,0 +1,15 @@
+<% require 'logger' %>
+allowed_file_types:
+  - '.rb'
+excluded_file_patterns:
+  - !ruby/regexp /^exe\//
+  - !ruby/regexp /^spec\//
+  - !ruby/regexp /^vendor\//
+  - !ruby/regexp /^config\//
+  - !ruby/regexp /^regression_tests\//
+  - !ruby/regexp /^\./
+log_level: <%= ::Logger::INFO %>
+src_root: 'lib/'
+spec_command: 'bundle exec rspec'
+test_dir: 'spec/'
+test_file_suffix: '_spec'


### PR DESCRIPTION
Adds git_spec.yml configuration file added in billthompson/git_spec/pull/9 but missed due to exclusion in .gitignore_global.